### PR TITLE
fix gold build by adding -fPIC

### DIFF
--- a/_other/golf-plugin/Makefile
+++ b/_other/golf-plugin/Makefile
@@ -4,7 +4,7 @@ LDFLAGS=$(shell pkg-config --libs r_core)
 R2_USER_PLUGINS=$(shell r2 -H R2_USER_PLUGINS)
 
 all:
-	$(CC) -g $(CFLAGS) $(LDFLAGS) -shared -o r2golf.$(LIBEXT) plugin.c
+	$(CC) -g $(CFLAGS) $(LDFLAGS) -fPIC -shared -o r2golf.$(LIBEXT) plugin.c
 
 install:
 	mkdir -p "$(R2_USER_PLUGINS)"


### PR DESCRIPTION
Here an attempt to fix #1 
tested on a centos7 machine and result in buildable golf plugin .so library